### PR TITLE
fix tag filters.

### DIFF
--- a/sources/assets/app.js
+++ b/sources/assets/app.js
@@ -21,9 +21,7 @@ $(".tag-filter").on("click", function() {
     projectList.filter(function(item) {
       var tags = item.values().tag.split(", ");
 
-      return tags.find(function(t) {
-        return t == tag;
-      });
+      return tags.indexOf(tag) >= 0;
     });
 
     filter = parent;


### PR DESCRIPTION
This should fix #4.

The problem is that Array#find is not cross-browser. See [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Browser_compatibility)
