### PR TITLE
Add json-serializer to the project list.

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -15,5 +15,6 @@
   { "name": "solnic/coercible",        "tags": ["coercion"] },
   { "name": "whitequark/ast",          "tags": ["utils", "ast"] },
   { "name": "patriciomacadden/hobbit", "tags": ["web"] },
-  { "name": "frodsan/mocoso",          "tags": ["testing"] }
+  { "name": "frodsan/mocoso",          "tags": ["testing"] },
+  { "name": "frodsan/json-serializer", "tags": ["utils"] }
 ]


### PR DESCRIPTION
I created this to replace Active Model Serializers gem.

UPDATE: I forgot to paste the link of the github repository: https://github.com/frodsan/json-serializer.
