### PR TITLE
Add Wisper gem to projects

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -15,5 +15,6 @@
   { "name": "solnic/coercible",        "tags": ["coercion"] },
   { "name": "whitequark/ast",          "tags": ["utils", "ast"] },
   { "name": "patriciomacadden/hobbit", "tags": ["web"] },
-  { "name": "frodsan/mocoso",          "tags": ["testing"] }
+  { "name": "frodsan/mocoso",          "tags": ["testing"] },
+  { "name": "krisleech/wisper",        "tags": ["events"] }
 ]


### PR DESCRIPTION
Pub/Sub for Ruby objects.

This PR adds a new tag, "events". I avoided "pub/sub" because of the slash.

https://github.com/krisleech/wisper

Articles: https://github.com/krisleech/wisper/wiki#articles
