### PR TITLE
Remove call to sleep 1, it returns 1 which corrupts the database

### DIFF
--- a/lib/micro.rb
+++ b/lib/micro.rb
@@ -60,7 +60,6 @@ class Project
     full = base.map do |json|
       puts "updating #{json["name"]}..."
       GithubProject.new(json["name"]).attributes.update(json)
-      sleep 1
     end
 
     File.open(DATABASE, "w") { |f| f << full.to_json }


### PR DESCRIPTION
This sleep 1 in the end of the map makes that the block has the wrong return value, so `db.json` looks like `[1,1,1,1,1,...]`.

See upcoming PR for how to better deal with the GH rate limiting.
