### PR TITLE
Create public/ if it does not exist

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 all: public/index.html public/about.html
 
 public/index.html: sources/index.mote
+	[ -d public ] || mkdir public
 	mote $< > $@
 	cp -R sources/assets public
 


### PR DESCRIPTION
When running `make` mote errors out because the `public` directory does not exist, and one needs to create it manually. This adds a line to the Makefile to create it when it's absent.
