### PR TITLE
Include phony, an E164 number handling tool.

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -44,5 +44,6 @@
    { "name": "plexus/fzip",                "tags": ["data", "functional"] },
    { "name": "plexus/ting",                "tags": ["language"] },
    { "name": "plexus/hexp",                "tags": ["web", "dom", "ast"] },
-   { "name": "plexus/asset_packer",        "tags": ["web", "assets"] }
+   { "name": "plexus/asset_packer",        "tags": ["web", "assets"] },
+   { "name": "floere/phony",               "tags": ["parsing", "phone"] },
  ]


### PR DESCRIPTION
[Phony](https://github.com/floere/phony) is a small library to handle E164 (international) phone numbers.

Production environments: It's used in airbnb.com, socialcam.com, zendesk.com (and many, many others).
