### PR TITLE
Add rubyqc

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -24,6 +24,7 @@
    { "name": "frodsan/json-serializer",    "tags": ["utils", "serializer"] },
    { "name": "asquera/psych-inherit-file", "tags": ["utils", "parsing", "yml"] },
    { "name": "guilleiguaran/nancy",        "tags": ["web"] },
+   { "name": "godfat/rubyqc",              "tags": ["testing"] },
    { "name": "pragtob/after_do",           "tags": ["utils", "aop"] },
    { "name": "janlelis/clipboard",         "tags": ["utils"] },
    { "name": "janlelis/paint",             "tags": ["utils", "terminal", "ansi"] },


### PR DESCRIPTION
[RubyQC](https://github.com/godfat/rubyqc) is a conceptual QuickCheck library for Ruby.

It's not a faithful port since Hsakell is totally different than Ruby.
However it's still benefit to use some of the ideas behind QuickCheck,
and we could also use RubyQC for generating arbitrary objects.
