### PR TITLE
Please add ribimaybe, a Maybe Functor, Applicative and Monad.

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -42,6 +42,7 @@
    { "name": "snusnu/substation",          "tags": ["framework"] },
    { "name": "snusnu/subway",              "tags": ["framework", "web", "rack"] },
    { "name": "plexus/fzip",                "tags": ["data", "functional"] },
+   { "name": "unsymbol/ribimaybe",         "tags": ["data", "functional"] },
    { "name": "plexus/ting",                "tags": ["language"] },
    { "name": "plexus/hexp",                "tags": ["web", "dom", "ast"] },
    { "name": "plexus/asset_packer",        "tags": ["web", "assets"] },


### PR DESCRIPTION
`ribimaybe` is a tiny Ruby library that provides a Maybe datatype which is a Functor, Applicative Functor and Monad instance. The entire project directory contains `193` lines of code (the main module itself contains `66`) and I hope for it to be used in production very soon.

**URL:** https://github.com/unsymbol/ribimaybe
