### PR TITLE
fix repo ownership for ribimaybe lib

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -55,5 +55,5 @@
    { "name": "ElMassimo/pakiderm",         "tags": ["memoization", "utils"] },
    { "name": "floere/phony",               "tags": ["utils"] },
    { "name": "restorando/rbrules",         "tags": ["utils"] },
-   { "name": "unsymbol/ribimaybe",         "tags": ["utils"] }
+   { "name": "filib/ribimaybe",            "tags": ["utils"] }
  ]


### PR DESCRIPTION
This repo has changed ownership, without this change `bin/update` fails as per issue #73 