### PR TITLE
Add curio, formatter-date and formatter-number

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -55,5 +55,8 @@
    { "name": "ElMassimo/pakiderm",         "tags": ["memoization", "utils"] },
    { "name": "floere/phony",               "tags": ["utils"] },
    { "name": "restorando/rbrules",         "tags": ["utils"] },
-   { "name": "filib/ribimaybe",            "tags": ["utils"] }
+   { "name": "filib/ribimaybe",            "tags": ["utils"] },
+   { "name": "terlar/curio",               "tags": ["enumerable", "collection"] },
+   { "name": "terlar/formatter-date",      "tags": ["utils", "formatter"] },
+   { "name": "terlar/formatter-number",    "tags": ["utils", "formatter"] }
  ]


### PR DESCRIPTION
This adds curio, a small enumerable collection library. That can be used
as an in-memory dictionary for objects.

This adds formatter-date, a date formatter with support for time zones.

This adds formatter-number, a simple number formatter with the goal to
support all kind of number formatting without any third party
extensions.

Closes #76
