### PR TITLE
add spectus

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -55,5 +55,6 @@
    { "name": "ElMassimo/pakiderm",         "tags": ["memoization", "utils"] },
    { "name": "floere/phony",               "tags": ["utils"] },
    { "name": "restorando/rbrules",         "tags": ["utils"] },
-   { "name": "filib/ribimaybe",            "tags": ["utils"] }
+   { "name": "filib/ribimaybe",            "tags": ["utils"] },
+   { "name": "fixrb/spectus",              "tags": ["testing"] }
  ]


### PR DESCRIPTION
This would add https://github.com/fixrb/spectus, an expectation library with [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)'s requirement levels, and some matchers for Ruby.
